### PR TITLE
Changed names to prevent collision

### DIFF
--- a/false.js
+++ b/false.js
@@ -74,7 +74,7 @@ let Storage = {
   {
     let str = "";
     let bFirst = true;
-    for( x in this.aData ) {
+    for( const x in this.aData ) {
       if( !bFirst ) str += ", ";
       str += x;
       str += ' = ';
@@ -1017,7 +1017,7 @@ function LoadProgram( zName, bResetWhenLoaded )
   }
 }
 
-function x()
+function CycleDebugLevel()
 {
   g_nDebugLevel = (g_nDebugLevel + 1) % 10;
   debug( 1, "Debug level now " + g_nDebugLevel );


### PR DESCRIPTION
the function x() at L1020 was being overwritten when Stack.dump() was called, so I fixed dump to use a local x, and changed x() to a more descriptive name just to be safe